### PR TITLE
feat: integrate new orderCount

### DIFF
--- a/src/components/shared/Alert/index.module.css
+++ b/src/components/shared/Alert/index.module.css
@@ -87,8 +87,8 @@ button.action {
 }
 
 .info {
-  border-color: var(--brand-alert-yellow);
-  color: #9f7e19;
+  border-color: var(--brand-blue);
+  color: var(--brand-blue);
 }
 
 .warning {


### PR DESCRIPTION
## Proposed Changes

  - Integrates new "payperuse" `orderCount` from contracting provider response in a new alert
  - Updates info color to pontus blue
  - Fixes an issue where selecting new algos, incorrectly updated the subscription state in UI
